### PR TITLE
fix: generated_images dict key

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -29,7 +29,7 @@ class StableDiffusionExecutor(Executor):
     def generate_image_from_document(self, document: Document, num_images: int) -> Document:
 
         with torch.autocast("cuda"):
-            generated_imgs = self.diffusion([document.text] * int(num_images))['sample']
+            generated_imgs = self.diffusion([document.text] * int(num_images))['images']
 
         for img in generated_imgs:
             _generated_document = Document(


### PR DESCRIPTION
Signed-off-by: Alex C-G <alexcg@outlook.com>

Executor was failing since `samples` key doesn't exist in the output of `self.diffusion()`. I changed it and confirm it works in this [notebook](https://colab.research.google.com/drive/1QEtofUXH_K89_9ueYJi_RY4XIRb_W76z#scrollTo=ZpQUVtzj1zAn).
